### PR TITLE
Feature/refactor meta

### DIFF
--- a/lib/conduit_mqtt/conn.ex
+++ b/lib/conduit_mqtt/conn.ex
@@ -28,7 +28,7 @@ defmodule ConduitMQTT.Conn do
 
   ## Server Callbacks
   def init(opts) do
-    # Process.flag(:trap_exit, true) #TODO what does this do?
+    #Process.flag(:trap_exit, true) #TODO what does this do?
     send(self(), :make_connection)
     # {:ok, state} = do_connect(%{opts: opts}) #syncrnous but doesn't help, connection still not ready on return
     {:ok, opts}

--- a/lib/conduit_mqtt/conn.ex
+++ b/lib/conduit_mqtt/conn.ex
@@ -28,7 +28,6 @@ defmodule ConduitMQTT.Conn do
 
   ## Server Callbacks
   def init(opts) do
-    #Process.flag(:trap_exit, true) #TODO what does this do?
     send(self(), :make_connection)
     # {:ok, state} = do_connect(%{opts: opts}) #syncrnous but doesn't help, connection still not ready on return
     {:ok, opts}

--- a/lib/conduit_mqtt/handler.ex
+++ b/lib/conduit_mqtt/handler.ex
@@ -4,7 +4,7 @@ defmodule ConduitMQTT.Handler do
   import Conduit.Message
   require Logger
 
-  def init([client_id: client_id, broker: broker, name: name, opts: opts] = args) do
+  def init([client_id: _client_id, broker: _broker, name: _name, opts: _opts] = args) do
     {:ok, args}
   end
 
@@ -40,10 +40,12 @@ defmodule ConduitMQTT.Handler do
     {:ok, state}
   end
 
-  def terminate(_reason, _state) do
+  def terminate(_reason, [client_id: client_id, broker: broker, name: name, opts: _opts] = _state) do
     # tortoise doesn't care about what you return from terminate/2,
     # that is in alignment with other behaviours that implement a
     # terminate-callback
+    ConduitMQTT.Meta.delete_client_id(broker, client_id)
+    ConduitMQTT.Meta.delete_subscription(broker, name)
     :ok
   end
 

--- a/lib/conduit_mqtt/meta.ex
+++ b/lib/conduit_mqtt/meta.ex
@@ -118,12 +118,12 @@ defmodule ConduitMQTT.Meta do
     |> meta_name()
     |> :ets.lookup({:subscription, subscription})
     |> case do
-         [] ->
-           fallback.()
+      [] ->
+        fallback.()
 
-         [{_, status} | _] ->
-           status
-       end
+      [{_, status} | _] ->
+        status
+    end
   end
 
   defp lookup_clients(broker) do
@@ -146,9 +146,13 @@ defmodule ConduitMQTT.Meta do
     count_of_clients_up = :ets.select_count(table, [{{{:client, :"$1"}, :up}, [], [true]}])
     count_of_subscribers_up = :ets.select_count(table, [{{{:subscription, :"$1"}, :up}, [], [true]}])
 
-    Logger.debug("Broker #{broker} has #{count_of_clients_up} of #{client_count} clients and #{count_of_subscribers_up} of #{subscriber_count} subscriptions up")
+    Logger.debug(
+      "Broker #{broker} has #{count_of_clients_up} of #{client_count} clients and #{count_of_subscribers_up} of #{
+        subscriber_count
+      } subscriptions up"
+    )
 
-    status = if (count_of_clients_up + count_of_subscribers_up == client_count + subscriber_count), do: :up, else: :down
+    status = if count_of_clients_up + count_of_subscribers_up == client_count + subscriber_count, do: :up, else: :down
     Logger.debug("Broker #{broker} is #{status}")
     status
   end

--- a/test/conduit_mqtt_test.exs
+++ b/test/conduit_mqtt_test.exs
@@ -1,6 +1,7 @@
 defmodule ConduitMQTTTest do
   @moduledoc false
   use ExUnit.Case, async: false
+  import Conduit.Message
   require Logger
 
   defmodule Broker do
@@ -76,7 +77,23 @@ defmodule ConduitMQTTTest do
 
     assert_receive {:broker, _}
     assert_receive {:broker, _}
+
   end
 
-  # TODO test both brokers getting same message and message from one broker to the other
+  test "broker recovers from terminating all clients and recieves a message" do
+
+    clients = ConduitMQTT.Meta.get_clients(Broker)
+    Enum.each(clients, fn [client_id, _] ->  Tortoise.Connection.disconnect(client_id) end)
+
+    ConduitMQTT.Util.wait_until(fn -> ConduitMQTT.Meta.get_broker_status(Broker) == :up end)
+
+    message =
+      %Conduit.Message{}
+      |> put_destination("foo/bar1")
+      |> put_body("test")
+
+    ConduitMQTT.publish(Broker, message, [], [])
+
+    assert_receive {:broker, _}
+  end
 end

--- a/test/conduit_mqtt_test.exs
+++ b/test/conduit_mqtt_test.exs
@@ -32,8 +32,7 @@ defmodule ConduitMQTTTest do
     ConduitMQTT.start_link(OtherBroker, [], %{}, opts)
 
     ConduitMQTT.Util.wait_until(fn ->
-      ConduitMQTT.Meta.get_broker_status(Broker) == :up &&
-        ConduitMQTT.Meta.get_broker_status(OtherBroker) == :up
+      ConduitMQTT.Meta.get_broker_status(Broker) == :up && ConduitMQTT.Meta.get_broker_status(OtherBroker) == :up
     end)
 
     :ok
@@ -77,13 +76,11 @@ defmodule ConduitMQTTTest do
 
     assert_receive {:broker, _}
     assert_receive {:broker, _}
-
   end
 
   test "broker recovers from terminating all clients and recieves a message" do
-
     clients = ConduitMQTT.Meta.get_clients(Broker)
-    Enum.each(clients, fn [client_id, _] ->  Tortoise.Connection.disconnect(client_id) end)
+    Enum.each(clients, fn [client_id, _] -> Tortoise.Connection.disconnect(client_id) end)
 
     ConduitMQTT.Util.wait_until(fn -> ConduitMQTT.Meta.get_broker_status(Broker) == :up end)
 

--- a/test/conduit_mqtt_test.exs
+++ b/test/conduit_mqtt_test.exs
@@ -31,8 +31,8 @@ defmodule ConduitMQTTTest do
     ConduitMQTT.start_link(OtherBroker, [], %{}, opts)
 
     ConduitMQTT.Util.wait_until(fn ->
-      ConduitMQTT.Meta.get_setup_status(Broker) == :complete &&
-        ConduitMQTT.Meta.get_setup_status(OtherBroker) == :complete
+      ConduitMQTT.Meta.get_broker_status(Broker) == :up &&
+        ConduitMQTT.Meta.get_broker_status(OtherBroker) == :up
     end)
 
     :ok


### PR DESCRIPTION
Make broker :up, :down status a pull calculation rather than a handler update state thing.  Avoids concurrency issue.  Also remove keys for subscribers and clients on terminate of their connections.